### PR TITLE
dev: graphdb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ results/*
 *.test.trig
 *.test.rw
 .kotlin
+# IDE build output
+bin/

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
@@ -24,6 +24,9 @@ suspend fun GspLayer1Context<GspMutateResponse>.loadModel() {
         branch()
     }
 
+    // optional commit message (forwarded by flexo-sysmlv2 from the SysML Commit description)
+    commitMessage = call.request.queryParameters["message"]
+
     // prep conditions
     val localConditions = DEFAULT_UPDATE_CONDITIONS.append {
         // assert HTTP preconditions

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchRead.kt
@@ -15,11 +15,17 @@ private val SPARQL_BGP_BRANCH: (Boolean, Boolean) -> String = { allBranches, all
         ${"optional {" iff allBranches}${"""
             ?$SPARQL_VAR_NAME_BRANCH a mms:Branch ;
                 mms:etag ?__mms_etag ;
-                ${"?branch_p ?branch_o ;" iff allData}
+                ${"?branch_p ?branch_o ;" iff (allData && !allBranches)}
                 .
         """.reindent(if(allBranches) 3 else 2)}
         ${"}" iff allBranches}
-        
+
+        ${"""
+            optional {
+                ?$SPARQL_VAR_NAME_BRANCH ?branch_p ?branch_o .
+            }
+        """.reindent(2) iff (allData && allBranches)}
+
         ${"""
             optional {
                 ?thing mms:branch ?$SPARQL_VAR_NAME_BRANCH ;
@@ -28,7 +34,7 @@ private val SPARQL_BGP_BRANCH: (Boolean, Boolean) -> String = { allBranches, all
             }
         """.reindent(2) iff allData}
     }
-    
+
     ${permittedActionSparqlBgp(Permission.READ_BRANCH, Scope.BRANCH,
         if(allBranches) "^morb:?$".toRegex() else null,
         if(allBranches) "" else null)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -3,6 +3,7 @@ package org.openmbee.flexo.mms.routes.sparql
 import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.apache.jena.rdf.model.Property
@@ -20,6 +21,8 @@ fun Route.commitModel() {
             repo()
             branch()
         }
+        // optional commit message (forwarded by flexo-sysmlv2 from the SysML Commit description)
+        commitMessage = call.request.queryParameters["message"]
         // parse query
         val sparqlUpdateAst = try {
             UpdateFactory.create(requestContext.update)


### PR DESCRIPTION
- Failed to list /commits : when replacing fuseki with graphdb. Same data, but GraphDB’s SPARQL optimizer drops wildcard property bindings (?branch_p ?branch_o) from an OPTIONAL block when joined with the access-control BGP — so mms:commit is never returned and sysmlv2 crashes. (last issue we discussed)
commit message never stored on DB. Forward commit message from sysmlv2 payload to layer1 to store it.

- Commit message never stored on DB. Forward commit message from sysmlv2 payload to layer1 to store it.