### PR TITLE
fix: remove trailing semicolons before dots in SPARQL/Turtle property…

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/AccessControl.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/AccessControl.kt
@@ -155,8 +155,7 @@ fun permittedActionSparqlBgp(
             ?__mms_policy a mms:Policy ;
                 mms:scope ?__mms_scope ;
                 mms:role ?__mms_role ;
-                ?__mms_policy_p ?__mms_policy_o ;
-                .
+                ?__mms_policy_p ?__mms_policy_o .
         }
 
         # deduce `?__mms_authMethod`
@@ -173,9 +172,7 @@ fun permittedActionSparqlBgp(
             # user belongs to some group
             graph m-graph:AccessControl.Agents {
                 ?__mms_group a mms:Group ;
-                    mms:id ?__mms_groupId ;
-                    .
-        
+                    mms:id ?__mms_groupId .
                 values ?__mms_groupId {
                     # @values groupId                
                 }
@@ -206,12 +203,9 @@ fun permittedActionSparqlBgp(
             ?__mms_scopeType rdfs:subClassOf*/mms:implies*/^rdfs:subClassOf* mms:${scope.type} .
 
             ?__mms_role a mms:Role ;
-                mms:permits ?__mms_directRolePermissions ;
-                .
-            
+                mms:permits ?__mms_directRolePermissions .
             ?__mms_directRolePermissions a mms:Permission ;
-                mms:implies* mms-object:Permission.${permission.id} ;
-                .
+                mms:implies* mms-object:Permission.${permission.id} .
         }
     """
 }
@@ -222,9 +216,7 @@ fun generateReadContextBgp(permission: Permission, id: String?=null): String {
         <${MMS_URNS.SUBJECT.context}${id?.let { ":$it" }?: ""}> a mms:Context ;
             mms:etag ?__mms_etag, ?elementEtag ;
             mms:appliedPolicy ?__mms_policy ;
-            mms:permit mms-object:Permission.${permission.id} ;
-            .
-
+            mms:permit mms-object:Permission.${permission.id} .
         # details the policy that was applied
         #?__mms_policy ?__mms_policy_p ?__mms_policy_o .
     """

--- a/src/main/kotlin/org/openmbee/flexo/mms/Conditions.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Conditions.kt
@@ -468,8 +468,7 @@ class ConditionsGroup(var conditions: List<Condition>) {
            
                     graph mor-graph:Metadata {         
                         ?srcRef a ?srcRefClass ;
-                            mms:commit ?srcCommit ;
-                            .
+                            mms:commit ?srcCommit .
                     }
                 """
             }
@@ -488,8 +487,7 @@ class ConditionsGroup(var conditions: List<Condition>) {
            
                     graph mor-graph:Metadata {         
                         ?dstRef a ?dstRefClass ;
-                            mms:commit ?dstCommit ;
-                            .
+                            mms:commit ?dstCommit .
                     }
                 """
             }

--- a/src/main/kotlin/org/openmbee/flexo/mms/Layer1Context.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Layer1Context.kt
@@ -557,8 +557,7 @@ class Layer1Context<TRequestContext: GenericRequest, out TResponseContext: Gener
                
                         graph mor-graph:Metadata {         
                             ?_refSource a ?__mms_refSourceClass ;
-                                mms:commit ?__mms_commitSource ;
-                                .
+                                mms:commit ?__mms_commitSource .
                         }
                     """ else ""} 
                     graph mor-graph:Metadata {

--- a/src/main/kotlin/org/openmbee/flexo/mms/SparqlBuilder.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/SparqlBuilder.kt
@@ -41,9 +41,7 @@ private fun SPARQL_INSERT_TRANSACTION(customProperties: String?=null, subTxnId: 
                 mms:permit ?_requiredPermission ;
                 mms:appliedPolicy ?__mms_policy ;
                 # mms:requestBody ?_requestBody ;
-                mms:requestBodyContentType ?_requestBodyContentType ;
-                ${pp(customProperties?: "", 4)}
-                .
+                mms:requestBodyContentType ?_requestBodyContentType${if(!customProperties.isNullOrBlank()) " ;\n                ${pp(customProperties, 4)}" else ""} .
         }
     """.trimIndent()
 }
@@ -208,8 +206,8 @@ open class WhereBuilder(
         return raw("""
             # match a successful transaction and its details
             graph m-graph:Transactions {
-                mt:${subTxnId?: ""} ?mt_p ?mt_o ;
-                    ${"mms:appliedPolicy ?__mms_policy ;" iff !noAccessControl}
+                mt:${subTxnId?: ""} ?mt_p ?mt_o${" ;" iff !noAccessControl}
+                    ${"mms:appliedPolicy ?__mms_policy" iff !noAccessControl}
                     .
                 
                 # a policy might have been created during this transaction
@@ -282,8 +280,7 @@ class TxnBuilder(
                     $policyCurie a mms:Policy ;
                         mms:subject mu: ;
                         mms:scope ${scope.id}: ;
-                        mms:role ${roles.joinToString(",") { "mms-object:Role.${it.id}" }}  ;
-                        .
+                        mms:role ${roles.joinToString(",") { "mms-object:Role.${it.id}" }}  .
                 """)
             }
         }
@@ -316,7 +313,10 @@ class InsertBuilder(
         if(null != layer1.branchId) properties["mms:branch"] = "morb:"
         if(null != layer1.scratchId) properties["mms:scratch"] = "mors:"
 
-        val propertiesSparql = properties.entries.fold("") { out, (pred, obj) -> "$out$pred $obj ;\n" }
+        val propertiesSparql = properties.entries.toList().let { entries ->
+            entries.dropLast(1).joinToString("") { (pred, obj) -> "$pred $obj ;\n" } +
+                entries.last().let { (pred, obj) -> "$pred $obj" }
+        }
 
         raw(SPARQL_INSERT_TRANSACTION(propertiesSparql, subTxnId))
 

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
@@ -236,8 +236,7 @@ fun AnyLayer1Context.genCommitUpdate(delete: String="", insert: String="", where
                     morb:
                         # replace branch pointer and etag
                         mms:commit ?baseCommit ;
-                        mms:etag ?branchEtag ;
-                        .
+                        mms:etag ?branchEtag .
                 }
                 $delete
             """)
@@ -261,16 +260,12 @@ fun AnyLayer1Context.genCommitUpdate(delete: String="", insert: String="", where
                         mms:data morc-data: ;
                         mms:createdBy mu: ;
                         mms:id ?_txnId ;
-                        mms:etag ?_txnId ;
-                        .
-            
+                        mms:etag ?_txnId .
                     # commit data
                     morc-data: a mms:Update ;
                         mms:patch ?_patchString ;
                         mms:insGraph ?_insGraph ;
-                        mms:delGraph ?_delGraph ;
-                        .
-            
+                        mms:delGraph ?_delGraph .
                     # update branch pointer and etag
                     morb: mms:commit morc: ;
                           mms:etag ?_txnId .
@@ -323,8 +318,7 @@ fun AnyLayer1Context.genDiffUpdate(diffTriples: String="", conditions: Condition
                         mms:srcCommit ?srcCommit ;
                         mms:dstCommit ?dstCommit ;
                         mms:insGraph ?insGraph ;
-                        mms:delGraph ?delGraph ;
-                        .
+                        mms:delGraph ?delGraph .
                 }
             """)
         }
@@ -555,11 +549,9 @@ suspend fun AnyLayer1Context.diffAndFinalizeCommit(dstGraphIri: String, srcGraph
             graph mor-graph:Metadata {
                 mor-lock:Commit.$transactionId a mms:Lock ;
                     mms:snapshot mor-snapshot:Model.$transactionId ;
-                    mms:commit morc: ;
-                    .
+                    mms:commit morc: .
                 mor-snapshot:Model.$transactionId a mms:Model ;
-                    mms:graph mor-graph:Model.$transactionId ;
-                    .
+                    mms:graph mor-graph:Model.$transactionId .
             }
         }
     """)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchRead.kt
@@ -14,8 +14,8 @@ private val SPARQL_BGP_BRANCH: (Boolean, Boolean) -> String = { allBranches, all
     graph mor-graph:Metadata {
         ${"optional {" iff allBranches}${"""
             ?$SPARQL_VAR_NAME_BRANCH a mms:Branch ;
-                mms:etag ?__mms_etag ;
-                ${"?branch_p ?branch_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?branch_p ?branch_o" iff allData}
                 .
         """.reindent(if(allBranches) 3 else 2)}
         ${"}" iff allBranches}
@@ -23,8 +23,7 @@ private val SPARQL_BGP_BRANCH: (Boolean, Boolean) -> String = { allBranches, all
         ${"""
             optional {
                 ?thing mms:branch ?$SPARQL_VAR_NAME_BRANCH ;
-                    ?thing_p ?thing_o ;
-                    .
+                    ?thing_p ?thing_o .
             }
         """.reindent(2) iff allData}
     }
@@ -39,9 +38,7 @@ private val SPARQL_CONSTRUCT_BRANCH: (Boolean, Boolean) -> String = { allBranche
     construct {
         ?$SPARQL_VAR_NAME_BRANCH a mms:Branch ;
             mms:etag ?__mms_etag ;
-            ?branch_p ?branch_o ;
-            .
-        
+            ?branch_p ?branch_o .
         ?thing ?thing_p ?thing_o .
         
         ${generateReadContextBgp(Permission.READ_BRANCH).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/BranchWrite.kt
@@ -100,8 +100,7 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
                       mms:snapshot ?_stgSnapshot .
                       
                 ?_stgSnapshot a mms:Staging ;
-                    mms:graph ?_stgGraph ;
-                    .
+                    mms:graph ?_stgGraph .
             }
             
             graph m-graph:Transactions {
@@ -112,8 +111,7 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
                 $autoPolicyCurie a mms:Policy ;
                     mms:subject mu: ;
                     mms:scope morb: ;
-                    mms:role mms-object:Role.AdminBranch ;
-                    .
+                    mms:role mms-object:Role.AdminBranch .
             }
         }
     """

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/CollectionRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/CollectionRead.kt
@@ -17,8 +17,8 @@ private val SPARQL_BGP_COLLECTION: (Boolean, Boolean) -> String = { allCollectio
         ${"optional {" iff allCollections}${"""
             ?$SPARQL_VAR_NAME_COLLECTION a mms:Collection ;
                 mms:etag ?__mms_etag ;
-                mms:org ?$SPARQL_VAR_NAME_ORG ;
-                ${"?collection_p ?collection_o ;" iff allData}
+                mms:org ?$SPARQL_VAR_NAME_ORG${" ;" iff allData}
+                ${"?collection_p ?collection_o" iff allData}
                 .
         """.reindent(if(allCollections) 3 else 2)}
         ${"}" iff allCollections}
@@ -35,8 +35,7 @@ private val SPARQL_CONSTRUCT_COLLECTION: (Boolean, Boolean) -> String = { allCol
     construct {
         ?$SPARQL_VAR_NAME_COLLECTION a mms:Collection ;
             mms:etag ?__mms_etag ;
-            ?collection_p ?collection_o ;
-            .
+            ?collection_p ?collection_o .
         ${generateReadContextBgp(Permission.READ_COLLECTION).reindent(2)}
     } where {
         ${SPARQL_BGP_COLLECTION(allCollections, allData).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/CommitRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/CommitRead.kt
@@ -14,8 +14,8 @@ private val SPARQL_BGP_COMMIT: (Boolean, Boolean) -> String = { allCommits, allD
     graph mor-graph:Metadata {
         ${"optional {" iff allCommits}${"""
             ?$SPARQL_VAR_NAME_COMMIT a mms:Commit ;
-                mms:etag ?__mms_etag ;
-                ${"?commit_p ?commit_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?commit_p ?commit_o" iff allData}
                 .
         """.reindent(if(allCommits) 3 else 2)}
         ${"}" iff allCommits}
@@ -23,8 +23,7 @@ private val SPARQL_BGP_COMMIT: (Boolean, Boolean) -> String = { allCommits, allD
         ${"""
             optional {
                 ?thing mms:commit ?$SPARQL_VAR_NAME_COMMIT ;
-                    ?thing_p ?thing_o ;
-                    .
+                    ?thing_p ?thing_o .
             }
         """.reindent(2) iff allData}
     }
@@ -39,9 +38,7 @@ private val SPARQL_CONSTRUCT_COMMIT: (Boolean, Boolean) -> String = { allCommits
     construct {
         ?$SPARQL_VAR_NAME_COMMIT a mms:Commit ;
             mms:etag ?__mms_etag ;
-            ?commit_p ?commit_o ;
-            .
-        
+            ?commit_p ?commit_o .
         ?thing ?thing_p ?thing_o .
         
         ${generateReadContextBgp(Permission.READ_COMMIT).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/GraphMaterialization.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/GraphMaterialization.kt
@@ -74,8 +74,7 @@ suspend fun AnyLayer1Context.materializeModelGraph(commitIri: String, targetGrap
                 mt:sequence
                     mms-txn:originCommit ?originCommit ;
                     mms-txn:originSnapshot ?originSnapshot ;
-                    mms-txn:originGraph ?originGraph ;
-                    .
+                    mms-txn:originGraph ?originGraph .
             }
         }
         where {
@@ -135,8 +134,7 @@ suspend fun AnyLayer1Context.materializeModelGraph(commitIri: String, targetGrap
                 mt:sequence
                     mms-txn:originCommit ?originCommit ;
                     mms-txn:originSnapshot ?originSnapshot ;
-                    mms-txn:originGraph ?originGraph ;
-                    .
+                    mms-txn:originGraph ?originGraph .
             }
         
             graph mor-graph:Metadata {
@@ -215,12 +213,9 @@ suspend fun AnyLayer1Context.materializeModelGraph(commitIri: String, targetGrap
             graph mor-graph:Metadata {
                 mor-lock:Commit.${transactionId} a mms:Lock ;
                     mms:commit ?_commitIri ;
-                    mms:snapshot ?_mdlSnapshot ;
-                    .
-
+                    mms:snapshot ?_mdlSnapshot .
                 ?_mdlSnapshot a mms:Model ;
-                    mms:graph ?_targetGraph ;
-                    .
+                    mms:graph ?_targetGraph .
             }
         }
         """

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/GroupRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/GroupRead.kt
@@ -14,8 +14,8 @@ private val SPARQL_BGP_GROUP: (Boolean, Boolean) -> String = { allGroups, allDat
     graph m-graph:AccessControl.Agents {
         ${"optional {" iff allGroups}${"""
             ?$SPARQL_VAR_NAME_GROUP a mms:Group ;
-                mms:etag ?__mms_etag ;
-                ${"?group_p ?group_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?group_p ?group_o" iff allData}
                 .
         """.reindent(if(allGroups) 3 else 2)}
         ${"}" iff allGroups}
@@ -23,8 +23,7 @@ private val SPARQL_BGP_GROUP: (Boolean, Boolean) -> String = { allGroups, allDat
         ${"""
             optional {
                 ?thing mms:group ?$SPARQL_VAR_NAME_GROUP ;
-                    ?thing_p ?thing_o ;
-                    .
+                    ?thing_p ?thing_o .
             }            
         """.reindent(2) iff allData}
     }
@@ -38,9 +37,7 @@ private val SPARQL_BGP_GROUP: (Boolean, Boolean) -> String = { allGroups, allDat
 private val SPARQL_CONSTRUCT_GROUP: (Boolean, Boolean) -> String = { allGroups, allData ->  """
     construct {
         ?$SPARQL_VAR_NAME_GROUP ?group_p ?group_o ;
-            mms:etag ?__mms_etag ;
-            .
-        
+            mms:etag ?__mms_etag .
         ?thing ?thing_p ?thing_o .
         
         ?groupPolicy ?groupPolicy_p ?groupPolicy_o .

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockRead.kt
@@ -15,8 +15,8 @@ private val SPARQL_BGP_LOCK: (Boolean, Boolean) -> String = { allLocks, allData 
     graph mor-graph:Metadata {
         ${"optional {" iff allLocks}${"""
             ?$SPARQL_VAR_NAME_LOCK a mms:Lock ;
-                mms:etag ?__mms_etag ;
-                ${"?lock_p ?lock_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?lock_p ?lock_o" iff allData}
                 .
         """.reindent(if(allLocks) 3 else 2)}
         ${"}" iff allLocks}
@@ -24,8 +24,7 @@ private val SPARQL_BGP_LOCK: (Boolean, Boolean) -> String = { allLocks, allData 
         ${"""
             optional {
                 ?thing mms:lock ?$SPARQL_VAR_NAME_LOCK ;
-                    ?thing_p ?thing_o ;
-                    .
+                    ?thing_p ?thing_o .
             }
         """.reindent(2) iff allData}
     }
@@ -39,9 +38,7 @@ private val SPARQL_BGP_LOCK: (Boolean, Boolean) -> String = { allLocks, allData 
 private val SPARQL_CONSTRUCT_LOCK: (Boolean, Boolean) -> String = { allLocks, allData ->  """
     construct {
         ?$SPARQL_VAR_NAME_LOCK ?lock_p ?lock_o ;
-            mms:etag ?__mms_etag ;
-            .
-        
+            mms:etag ?__mms_etag .
         ?thing ?thing_p ?thing_o .
 
         ?lockPolicy ?lockPolicy_p ?lockPolicy_o .

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
@@ -85,8 +85,7 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
                 $autoPolicyCurie a mms:Policy ;
                     mms:subject mu: ;
                     mms:scope morl: ;
-                    mms:role mms-object:Role.AdminLock ;
-                    .
+                    mms:role mms-object:Role.AdminLock .
             }
         }
     """

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/OrgRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/OrgRead.kt
@@ -14,8 +14,8 @@ private val SPARQL_BGP_ORG: (Boolean, Boolean) -> String = { allOrgs, allData ->
     graph m-graph:Cluster {
         ${"optional {" iff allOrgs}${"""
             ?$SPARQL_VAR_NAME_ORG a mms:Org ;
-                mms:etag ?__mms_etag ;
-                ${"?org_p ?org_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?org_p ?org_o" iff allData}
                 .
         """.reindent(if(allOrgs) 3 else 2)}
         ${"}" iff allOrgs}
@@ -29,8 +29,7 @@ private val SPARQL_BGP_ORG: (Boolean, Boolean) -> String = { allOrgs, allData ->
 private val SPARQL_CONSTRUCT_ORG: (Boolean, Boolean) -> String = { allOrgs, allData ->  """
     construct {
         ?$SPARQL_VAR_NAME_ORG ?org_p ?org_o ;
-            mms:etag ?__mms_etag ;
-            .        
+            mms:etag ?__mms_etag .
         ${generateReadContextBgp(Permission.READ_ORG).reindent(2)}
     } where {
         ${SPARQL_BGP_ORG(allOrgs, allData).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/RepoRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/RepoRead.kt
@@ -16,8 +16,8 @@ private val SPARQL_BGP_REPO: (Boolean, Boolean) -> String = { allRepos, allData 
         ${"optional {" iff allRepos}${"""
             ?$SPARQL_VAR_NAME_REPO a mms:Repo ;
                 mms:etag ?__mms_etag ;
-                mms:org ?$SPARQL_VAR_NAME_ORG ;
-                ${"?repo_p ?repo_o ;" iff allData}
+                mms:org ?$SPARQL_VAR_NAME_ORG${" ;" iff allData}
+                ${"?repo_p ?repo_o" iff allData}
                 .                
         """.reindent(if(allRepos) 3 else 2)}
         ${"}" iff allRepos}
@@ -34,8 +34,7 @@ private val SPARQL_CONSTRUCT_REPO: (Boolean, Boolean) -> String = { allRepos, al
     construct {
         ?$SPARQL_VAR_NAME_REPO a mms:Repo ;
             mms:etag ?__mms_etag ;
-            ?repo_p ?repo_o ;
-            .
+            ?repo_p ?repo_o .
         ${generateReadContextBgp(Permission.READ_REPO).reindent(2)}
     } where {
         ${SPARQL_BGP_REPO(allRepos, allData).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/RepoWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/RepoWrite.kt
@@ -216,14 +216,10 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
                             mms:message ?_commitMessage ;
                             mms:data morc-data: ;
                             mms:etag ?_commitEtag ;
-                            mms:id "$transactionId" ;
-                            .
-                
+                            mms:id "$transactionId" .
                         # root commit data
                         morc-data: a mms:Load ;
-                            mms:body ""^^mms-datatype:sparql ;
-                            .
-
+                            mms:body ""^^mms-datatype:sparql .
                         # default branch
                         morb: a mms:Branch ;
                             mms:id ?_branchId ;
@@ -232,26 +228,19 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
                             mms:snapshot ?_staging ;
                             dct:title "Master"@en ;
                             mms:createdBy mu: ;
-                            mms:created ?_now ;
-                            .
-                            
+                            mms:created ?_now .
                         # model snapshot
                         mor-lock:Commit.$transactionId a mms:Lock ;
                             mms:commit morc: ;
                             mms:snapshot ?_model ;
                             mms:created ?_now ;
-                            mms:createBy mu: ;
-                            .
-                        
+                            mms:createBy mu: .
                         # initial model graph
                         ?_model a mms:Model ;
-                            mms:graph ?_modelGraph ;
-                            .
-                        
+                            mms:graph ?_modelGraph .
                         # initial staging graph
                         ?_staging a mms:Staging ;
-                            mms:graph ?_stagingGraph ;
-                            .
+                            mms:graph ?_stagingGraph .
                     """)
                 }
 

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/ScratchRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/ScratchRead.kt
@@ -15,8 +15,8 @@ private val SPARQL_BGP_SCRATCH: (Boolean, Boolean) -> String = { allScratches, a
     graph mor-graph:Metadata {
         ${"optional {" iff allScratches}${"""
             ?$SPARQL_VAR_NAME_SCRATCH a mms:Scratch ;
-                mms:etag ?__mms_etag ;
-                ${"?scratch_p ?scratch_o ;" iff allData}
+                mms:etag ?__mms_etag${" ;" iff allData}
+                ${"?scratch_p ?scratch_o" iff allData}
                 .
         """.reindent(if(allScratches) 3 else 2)}
         ${"}" iff allScratches}
@@ -32,8 +32,7 @@ private val SPARQL_CONSTRUCT_SCRATCH: (Boolean, Boolean) -> String = { allScratc
     construct {
         ?$SPARQL_VAR_NAME_SCRATCH a mms:Scratch ;
             mms:etag ?__mms_etag ;
-            ?scratch_p ?scratch_o ;
-            .
+            ?scratch_p ?scratch_o .
         ${generateReadContextBgp(Permission.READ_SCRATCH).reindent(2)}
     } where {
         ${SPARQL_BGP_SCRATCH(allScratches, allData).reindent(2)}

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -19,8 +19,7 @@ const val SPARQL_BIND_ARTIFACT = """
     ?artifact a mms:Artifact ;
         mms:contentType ?contentType ;
         mms:body ?body ;
-        ?artifact_p ?artifact_o ;
-        . 
+        ?artifact_p ?artifact_o .
 """
 
 data class DecodedArtifact(

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
@@ -73,8 +73,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
                         mms:created ?_now ;
                         mms:createdBy mu: ;
                         mms:contentType ${escapeLiteral(requestBodyContentType)} ;
-                        $storageFragment ; 
-                        .
+                        $storageFragment .
                 """)
             }
         }


### PR DESCRIPTION
… lists

Virtuoso's SPARQL-BI parser rejects the pattern '; .' (dot immediately after semicolon) which is permitted in pure SPARQL 1.1 but not portable across all backends. This caused HTTP 500 errors on create-project and other write operations when using Virtuoso as the RDF backend.

Changes:
- Remove trailing semicolons before terminating dots in all static SPARQL/Turtle templates (19 files)
- Fix conditional (iff) patterns in BGP read queries so the last property in the list does not emit a semicolon before the dot
- Fix dynamic property list generation in SparqlBuilder.subtxn() to not append semicolon to the last property
- Fix SPARQL_INSERT_TRANSACTION template to handle custom properties without trailing semicolons

source pr: https://github.com/JPL-Devin/flexo-mms-layer1-service/pull/20