### PR TITLE
fix: add checkout step to scan job to resolve SonarCloud missing blob…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
       name: node/default
     working_directory: /home/circleci/flexo-mms-layer1-service
     steps:
-      - checkout:
-          depth: null
+      - checkout
       - restore_cache:
           name: Restore NPM package Cache
           keys:
@@ -62,12 +61,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      #- checkout
-      #- run:
-      #    name: Fetch full git history for SonarCloud blame
-      #    command: |
-      #      git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-      #      git fetch
+      - checkout
+      - run:
+          name: Fetch full git history for SonarCloud blame
+          command: |
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              git fetch --unshallow
+            fi
       - sonarcloud/scan
 
   deploy_snapshot:


### PR DESCRIPTION
… error

The SonarCloud scan was failing during the SCM Publisher (git blame) phase with MissingObjectException because the .git directory from the workspace was incomplete — objects were lost during workspace transfer between jobs.

Changes:
- Add checkout step after attach_workspace in the scan job so git fetches any missing objects from the remote
- Add safety step to unshallow the repository if the checkout is shallow
- Remove ambiguous depth: null from generate_schema checkout