### PR TITLE
Support RS256 token verification via optional JWKS endpoint alongside HMAC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-auth:$ktorVersion")
     implementation("io.ktor:ktor-server-auth-jwt:$ktorVersion")
+    // JWKS fetching for optional RS256 verification (explicit, though ktor-server-auth-jwt provides it transitively)
+    implementation("com.auth0:jwks-rsa:0.22.2")
     implementation("io.ktor:ktor-server-call-logging:$ktorVersion")
     implementation("io.ktor:ktor-server-conditional-headers:$ktorVersion")
     implementation("io.ktor:ktor-server-cors:$ktorVersion")

--- a/src/main/kotlin/org/openmbee/flexo/mms/server/Authentication.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/server/Authentication.kt
@@ -1,25 +1,73 @@
 package org.openmbee.flexo.mms.server
 
+import com.auth0.jwk.JwkProvider
+import com.auth0.jwk.JwkProviderBuilder
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.http.auth.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
+import java.net.URI
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.TimeUnit
 
 fun Application.configureAuthentication() {
     authentication {
         jwt {
-            val jwtAudience = this@configureAuthentication.environment.config.property("jwt.audience").getString()
-            val issuer = this@configureAuthentication.environment.config.property("jwt.domain").getString()
-            val secret = this@configureAuthentication.environment.config.property("jwt.secret").getString()
-            realm = this@configureAuthentication.environment.config.property("jwt.realm").getString()
+            val config = this@configureAuthentication.environment.config
+            val jwtAudience = config.property("jwt.audience").getString()
+            val issuer = config.property("jwt.domain").getString()
+            val secret = config.property("jwt.secret").getString()
+            realm = config.property("jwt.realm").getString()
 
-            verifier(
-                JWT.require(Algorithm.HMAC256(secret))
-                    .withAudience(jwtAudience)
-                    .withIssuer(issuer)
+            // legacy shared-secret verifier; remains the default and the fallback during RS256 migration
+            val hmacVerifier = JWT.require(Algorithm.HMAC256(secret))
+                .withAudience(jwtAudience)
+                .withIssuer(issuer)
+                .build()
+
+            // optional JWKS endpoint (e.g. the sso-auth-service's /.well-known/jwks.json) enabling
+            // asymmetric RS256 verification so that no service other than the token issuer needs to
+            // hold key material capable of forging tokens
+            val jwksUrl = config.propertyOrNull("jwt.jwksUrl")?.getString()
+            val jwkProvider: JwkProvider? = jwksUrl?.takeIf { it.isNotBlank() }?.let {
+                JwkProviderBuilder(URI.create(it).toURL())
+                    .cached(10, 24, TimeUnit.HOURS)
+                    .rateLimited(10, 1, TimeUnit.MINUTES)
                     .build()
-            )
+            }
+
+            // select the verifier per-token based on its header: RS256 tokens with a key id are
+            // verified against the JWKS (when configured); everything else falls back to HMAC.
+            // this permits both token types to coexist during a migration window.
+            verifier { httpAuthHeader: HttpAuthHeader ->
+                val token = (httpAuthHeader as? HttpAuthHeader.Single)?.blob
+                    ?: return@verifier hmacVerifier
+
+                val decoded = try {
+                    JWT.decode(token)
+                } catch(e: Exception) {
+                    return@verifier hmacVerifier
+                }
+
+                if(jwkProvider != null && decoded.algorithm == "RS256" && decoded.keyId != null) {
+                    try {
+                        val publicKey = jwkProvider.get(decoded.keyId).publicKey as RSAPublicKey
+                        JWT.require(Algorithm.RSA256(publicKey, null))
+                            .withAudience(jwtAudience)
+                            .withIssuer(issuer)
+                            .build()
+                    } catch(e: Exception) {
+                        // JWKS fetch/key lookup failed; fall back so the request 401s instead of 500ing
+                        this@configureAuthentication.log.warn("JWKS key lookup failed for kid=${decoded.keyId}: ${e.message}")
+                        hmacVerifier
+                    }
+                } else {
+                    hmacVerifier
+                }
+            }
+
             validate { credential ->
                 if (credential.payload.audience.contains(jwtAudience)) {
                     UserDetailsPrincipal(

--- a/src/main/resources/application.conf.example
+++ b/src/main/resources/application.conf.example
@@ -60,4 +60,11 @@ jwt {
     realm = ${?JWT_REALM}
     secret = "test1234"
     secret = ${?JWT_SECRET}
+
+    # optional JWKS endpoint for asymmetric (RS256) token verification, e.g. the
+    # sso-auth-service's /.well-known/jwks.json. When set, RS256 tokens bearing a key id
+    # are verified against it; HS256 tokens continue to verify against `secret`, allowing
+    # both to coexist during migration. Unset (default) preserves HMAC-only behavior.
+    # jwksUrl = "http://sso-auth-service:3000/sso/.well-known/jwks.json"
+    jwksUrl = ${?JWT_JWKS_URL}
 }


### PR DESCRIPTION
This PR was written by Claude Fable and reviewed by me.

### Summary
 
Adds opt-in asymmetric token verification. When `jwt.jwksUrl` (env `JWT_JWKS_URL`) is configured — e.g. pointing at the sso-auth-service's `/.well-known/jwks.json` — the verifier is selected per token from its header: RS256 tokens bearing a `kid` are verified against the JWKS; everything else falls back to the existing HMAC shared secret. Both token types therefore coexist during a migration window, allowing a zero-downtime cutover after which the shared secret can be retired.
 
Motivation: under multi-org, the shared HMAC secret is held by every minting service and can forge any user in any org. With RS256, only the token issuer holds forging capable key material.
 
### Changes
 
- `server/Authentication.kt`: per-token verifier selection; JWKS provider with
  caching (10 keys / 24 h) and rate limiting; JWKS lookup failures degrade to a 401
  (HMAC fallback) rather than a 500
- `build.gradle.kts`: explicit `com.auth0:jwks-rsa` (already transitive via
  ktor-server-auth-jwt)
- `application.conf.example`: documents `jwt.jwksUrl`
### Backward compatibility
 
- `jwt.jwksUrl` unset (default): behavior is byte-for-byte the previous HMAC-only path; existing deployments and tests are unaffected
- `validate {}` block, `UserDetailsPrincipal`, and the `username`/`groups` claim contract untouched


### Testing notes
 
- Compiles clean under JDK 21 (`./gradlew build -x test`); integration suite requires the Fuseki docker-compose environment (HMAC path exercises existing coverage)
- Suggested added test: spin up a stub JWKS endpoint, mint an RS256 token, verify acceptance; verify an RS256 token with unknown `kid` yields 401 and an HS256 token still authenticates with `jwksUrl` set