### PR TITLE
fix(diff): make POST /diffs functional with repo-addressed IRIs

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Diffs.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Diffs.kt
@@ -20,8 +20,14 @@ fun Route.crudDiffs() {
         }
 
         // create a new diff
-        post {
+        post { slug ->
+            // set diff id on context so the diff is minted at {repo}/diffs/{slug}
+            diffId = slug
+
             createDiff()
         }
+
+        // method not allowed
+        otherwiseNotAllowed("diffs")
     }
 }

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
@@ -476,6 +476,40 @@ suspend fun AnyLayer1Context.diffAndFinalizeCommit(dstGraphIri: String, srcGraph
     val deleteModel = parseModelStripPrefixes(RdfContentTypes.Turtle, deleteDataResponseText)
     // empty delta (no changes)
     if (insertModel.isEmpty && deleteModel.isEmpty) {
+        // remove the diff metadata and auto-created policy inserted by the diff update above;
+        // the commit this diff describes will never be created, so leaving them would accrete a
+        // dangling mms:Diff and an orphaned policy on every no-op update
+        executeSparqlUpdate("""
+            delete {
+                graph mor-graph:Metadata {
+                    ?diff ?diff_p ?diff_o .
+                }
+                graph m-graph:AccessControl.Policies {
+                    ?createdPolicy ?createdPolicy_p ?createdPolicy_o .
+                }
+                graph m-graph:Transactions {
+                    mt: mms:createdPolicy ?createdPolicy .
+                }
+            }
+            where {
+                graph mor-graph:Metadata {
+                    ?diff a mms:Diff ;
+                        mms:dstCommit morc: ;
+                        ?diff_p ?diff_o .
+                }
+                optional {
+                    graph m-graph:Transactions {
+                        mt: mms:createdPolicy ?createdPolicy .
+                    }
+                    graph m-graph:AccessControl.Policies {
+                        ?createdPolicy ?createdPolicy_p ?createdPolicy_o .
+                    }
+                }
+            }
+        """) {
+            prefixes(prefixes)
+        }
+
         // locate branch node
         val branchNode = diffConstructModel.createResource(prefixes["morb"])
         // get its etag value

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Model.kt
@@ -290,7 +290,7 @@ fun AnyLayer1Context.genCommitUpdate(delete: String="", insert: String="", where
 /**
  *   Used by ModelLoad to get difference between current staging graph and newly loaded graph in the form of delete/insert graphs
  */
-fun AnyLayer1Context.genDiffUpdate(diffTriples: String="", conditions: ConditionsGroup?=null, rawWhere: String?=null): String {
+fun AnyLayer1Context.genDiffUpdate(diffTriples: String="", conditions: ConditionsGroup?=null, rawWhere: String?=null, explicitDiffIri: String?=null): String {
     return buildSparqlUpdate {
         insert {
             subtxn("diff", mapOf(
@@ -304,40 +304,49 @@ fun AnyLayer1Context.genDiffUpdate(diffTriples: String="", conditions: Condition
 
             raw("""
                 graph ?insGraph {
-                    ?ins_s ?ins_p ?ins_o .    
+                    ?ins_s ?ins_p ?ins_o .
                 }
-                
+
                 graph ?delGraph {
                     ?del_s ?del_p ?del_o .
                 }
-                
+
                 graph mor-graph:Metadata {
                     ?diff a mms:Diff ;
                         mms:id ?diffId ;
+                        mms:etag ?diffId ;
                         mms:createdBy mu: ;
                         mms:srcCommit ?srcCommit ;
                         mms:dstCommit ?dstCommit ;
                         mms:insGraph ?insGraph ;
                         mms:delGraph ?delGraph .
+
+                    $diffTriples
                 }
             """)
         }
         where {
             raw("""
+                ${conditions?.requiredPatterns()?.joinToString("\n") ?: ""}
+
                 ${rawWhere?: ""}
-                
+
                 bind(
                     sha256(
                         concat(str(?dstCommit), "\n", str(?srcCommit))
                     ) as ?diffId
                 )
-                
-                bind(
-                    iri(
-                        concat(str(?dstCommit), "/diffs/", ?diffId)
-                    ) as ?diff
-                )
-                
+
+                ${if(explicitDiffIri != null) """
+                    bind(<$explicitDiffIri> as ?diff)
+                """ else """
+                    bind(
+                        iri(
+                            concat(str(?dstCommit), "/diffs/", ?diffId)
+                        ) as ?diff
+                    )
+                """}
+
                 bind(
                     iri(
                         concat(str(mor-graph:), "Diff.Ins.", ?diffId)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/DiffCreate.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/DiffCreate.kt
@@ -5,12 +5,15 @@ import io.ktor.server.response.*
 import org.openmbee.flexo.mms.*
 import org.openmbee.flexo.mms.server.LdpDcLayer1Context
 import org.openmbee.flexo.mms.server.LdpPostResponse
+import org.openmbee.flexo.mms.routes.sparql.deleteTransaction
 import org.openmbee.flexo.mms.routes.sparql.genDiffUpdate
 import java.security.MessageDigest
 
 
-// default starting conditions for any calls to create a lock
-private val DEFAULT_CONDITIONS = COMMIT_CRUD_CONDITIONS.append {
+// default starting conditions for any calls to create a diff. the repo must exist; the src and
+// dst refs are validated by appendSrcRef()/appendDstRef() (a diff request has no commit in its
+// path, so commit-level conditions do not apply here)
+private val DEFAULT_CONDITIONS = REPO_CRUD_CONDITIONS.append {
     // require that the user has the ability to create diffs on a repo-level scope
     permit(Permission.CREATE_DIFF, Scope.REPO)
 
@@ -46,7 +49,7 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.createDiff() {
     var createDiffUserDataTriples = ""
 
     // process RDF body from user about this new diff
-    filterIncomingStatements("morl") {
+    filterIncomingStatements("mord") {
         // relative to this diff node
         diffNode().apply {
             // assert cardinality for src and dst refs
@@ -73,26 +76,26 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.createDiff() {
     // extend the default conditions with requirements for user-specified src and dst refs
     val localConditions = DEFAULT_CONDITIONS.appendSrcRef().appendDstRef()
 
-    // prep SPARQL UPDATE string
+    // prep SPARQL UPDATE string; the diff is minted at the repo-addressed IRI from the request
     val updateString = genDiffUpdate(createDiffUserDataTriples, localConditions, """
         graph mor-graph:Metadata {
             # select the commit pointed to by the source ref
             ?srcRef mms:commit ?srcCommit .
-            
+
             # locate its corresponding snapshot and model graph
             ?srcCommit ^mms:commit/mms:snapshot ?srcSnapshot .
-            ?srcSnapshot a mms:Model ; 
+            ?srcSnapshot a mms:Model ;
                 mms:graph ?srcGraph  .
-            
-            # select the commit pointed to by the destination ref 
+
+            # select the commit pointed to by the destination ref
             ?dstRef mms:commit ?dstCommit .
-            
+
             # locate its corresponding snapshot and model graph
             ?dstCommit ^mms:commit/mms:snapshot ?dstSnapshot .
-            ?dstSnapshot a mms:Model ; 
+            ?dstSnapshot a mms:Model ;
                 mms:graph ?dstGraph .
         }
-    """)
+    """, explicitDiffIri=prefixes["mord"]!!)
 
     // execute update
     executeSparqlUpdate(updateString) {
@@ -141,21 +144,12 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.createDiff() {
     // check that the user-supplied HTTP preconditions were met
     handleEtagAndPreconditions(constructModel, prefixes["mord"])
 
+    // provide location of new resource
+    call.response.header(HttpHeaders.Location, prefixes["mord"]!!)
+
     // respond
-    call.respondText(constructResponseText, RdfContentTypes.Turtle)
+    call.respondText(constructResponseText, RdfContentTypes.Turtle, HttpStatusCode.Created)
 
-    // delete transaction
-    run {
-        // submit update
-        val dropResponseText = executeSparqlUpdate("""
-            delete where {
-                graph m-graph:Transactions {
-                    mt: ?p ?o .
-                }
-            }
-        """)
-
-        // log response
-        log.info(dropResponseText)
-    }
+    // delete transaction (including the mt:diff subtransaction created by the diff update)
+    deleteTransaction()
 }

--- a/src/test/kotlin/org/openmbee/flexo/mms/DiffCreateTest.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/DiffCreateTest.kt
@@ -1,0 +1,161 @@
+package org.openmbee.flexo.mms
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.testing.ApplicationTestBuilder
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP
+import org.apache.jena.vocabulary.DCTerms
+import org.apache.jena.vocabulary.RDF
+import org.openmbee.flexo.mms.util.*
+
+/**
+ * Tests diff creation via POST /orgs/{org}/repos/{repo}/diffs with repo-addressed diff IRIs.
+ */
+class DiffCreateTest : RefAny() {
+
+    private val lockId = "before-change"
+    private val lockPath = "$demoRepoPath/locks/$lockId"
+    private val diffsPath = "$demoRepoPath/diffs"
+
+    private fun askBackend(query: String): Boolean {
+        return QueryExecutionHTTP.service(backend.getQueryUrl()).query(query).build().use {
+            it.execAsk()
+        }
+    }
+
+    private fun diffBody(extra: String = ""): String {
+        return withAllTestPrefixes("""
+            <>
+                mms:srcRef <${localIri(lockPath)}> ;
+                mms:dstRef <${localIri(masterBranchPath)}> ;
+                .
+            $extra
+        """.trimIndent())
+    }
+
+    /**
+     * Commits a change on master, locks the pre-change commit, commits another change, so the
+     * lock and master differ by exactly one inserted triple.
+     */
+    private suspend fun ApplicationTestBuilder.setupDivergentRefs() {
+        commitModel(masterBranchPath, withAllTestPrefixes("""
+            insert data {
+                <urn:test:base> <urn:test:p> <urn:test:o> .
+            }
+        """.trimIndent()))
+
+        createLock(demoRepoPath, masterBranchPath, lockId)
+
+        commitModel(masterBranchPath, withAllTestPrefixes("""
+            insert data {
+                <urn:test:added> <urn:test:p> <urn:test:o> .
+            }
+        """.trimIndent()))
+    }
+
+    init {
+        "create diff between lock and branch" {
+            testApplication {
+                setupDivergentRefs()
+
+                httpPost(diffsPath) {
+                    header(HttpHeaders.SLUG, "my-diff")
+                    setTurtleBody(diffBody())
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.Created
+                    this.headers[HttpHeaders.Location] shouldBe localIri("$diffsPath/my-diff")
+
+                    // the response carries the diff's metadata at its repo-addressed IRI
+                    this includesTriples {
+                        subject(localIri("$diffsPath/my-diff")) {
+                            includes(
+                                RDF.type exactly MMS.Diff,
+                            )
+                        }
+                    }
+                }
+
+                // the ins graph of the diff contains exactly the added triple
+                withClue("diff ins graph should contain the triple added after the lock") {
+                    askBackend("""
+                        PREFIX mms: <https://mms.openmbee.org/rdf/ontology/>
+                        ASK {
+                            GRAPH <${localIri("$demoRepoPath/graphs/Metadata")}> {
+                                <${localIri("$diffsPath/my-diff")}> mms:insGraph ?insGraph .
+                            }
+                            GRAPH ?insGraph {
+                                <urn:test:added> <urn:test:p> <urn:test:o> .
+                            }
+                        }
+                    """.trimIndent()) shouldBe true
+                }
+            }
+        }
+
+        "create diff with extra user metadata" {
+            testApplication {
+                setupDivergentRefs()
+
+                httpPost(diffsPath) {
+                    header(HttpHeaders.SLUG, "titled-diff")
+                    setTurtleBody(diffBody("""
+                        <> dct:title "A titled diff"@en .
+                    """.trimIndent()))
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.Created
+
+                    this includesTriples {
+                        subject(localIri("$diffsPath/titled-diff")) {
+                            includes(
+                                RDF.type exactly MMS.Diff,
+                                DCTerms.title exactly "A titled diff".en,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        "create diff without slug generates an id" {
+            testApplication {
+                setupDivergentRefs()
+
+                httpPost(diffsPath) {
+                    setTurtleBody(diffBody())
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.Created
+                    this.headers[HttpHeaders.Location]!! shouldStartWith localIri("$diffsPath/")
+                }
+            }
+        }
+
+        "create diff leaves no dangling transaction" {
+            testApplication {
+                setupDivergentRefs()
+
+                httpPost(diffsPath) {
+                    header(HttpHeaders.SLUG, "txn-check-diff")
+                    setTurtleBody(diffBody())
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.Created
+                }
+
+                withClue("transactions graph should be empty after diff creation") {
+                    askBackend("""
+                        ASK {
+                            GRAPH <$ROOT_CONTEXT/graphs/Transactions> {
+                                ?txn ?p ?o .
+                            }
+                        }
+                    """.trimIndent()) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/openmbee/flexo/mms/DiffCreateTest.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/DiffCreateTest.kt
@@ -135,6 +135,42 @@ class DiffCreateTest : RefAny() {
             }
         }
 
+        "no-op update leaves no dangling diff metadata" {
+            testApplication {
+                val body = withAllTestPrefixes("""
+                    insert data {
+                        <urn:test:noop> <urn:test:p> <urn:test:o> .
+                    }
+                """.trimIndent())
+
+                // first update commits the change
+                commitModel(masterBranchPath, body)
+
+                // identical update is a no-op: responds without creating a commit
+                httpPost("$masterBranchPath/update") {
+                    setSparqlUpdateBody(body)
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.OK
+                }
+
+                // every mms:Diff must reference a commit that exists
+                withClue("no diff should reference a commit that was never created") {
+                    askBackend("""
+                        PREFIX mms: <https://mms.openmbee.org/rdf/ontology/>
+                        ASK {
+                            GRAPH <${localIri("$demoRepoPath/graphs/Metadata")}> {
+                                ?diff a mms:Diff ;
+                                    mms:dstCommit ?dstCommit .
+                                FILTER NOT EXISTS {
+                                    ?dstCommit a mms:Commit .
+                                }
+                            }
+                        }
+                    """.trimIndent()) shouldBe false
+                }
+            }
+        }
+
         "create diff leaves no dangling transaction" {
             testApplication {
                 setupDivergentRefs()


### PR DESCRIPTION
## Problem

`POST /orgs/{org}/repos/{repo}/diffs` has never worked. Compounding defects: the route never set `diffId` (every `mord:` reference resolved to the never-URN), the body was filtered against the **lock** prefix, the base conditions required a commit in the request path (404 on every request), `genDiffUpdate` ignored both its `diffTriples` and `conditions` parameters (user metadata dropped; no permit/uniqueness/ref validation at update time; `mms:appliedPolicy` never written, making the validation construct unmatchable so even successful writes returned errors), and cleanup deleted `mt:` while the transaction was created as `mt:diff`. There were zero diff tests.

Separately, the internal commit pipeline's empty-delta path (an idempotent client re-submitting the same update) permanently accreted a dangling `mms:Diff` referencing a never-created commit plus an orphaned `AutoDiffOwner` policy, on every no-op update.

## Fix

- **`c97ee0e`** — diffs are minted at repo-addressed IRIs `{repo}/diffs/{id}` (Slug header or generated), consistent with every other resource; the commit-pair sha256 is retained as `mms:id` and etag. The internal pipeline keeps its hash-derived IRIs. `genDiffUpdate` now actually embeds its conditions and user metadata. Responds 201 + Location.
- **`e393c26`** — the empty-delta path deletes the diff metadata and the transaction's created policy before responding.

## Tests

New `DiffCreateTest` (5 tests): diff between a lock and a branch including ins-graph content verification, extra user metadata, generated ids, transaction cleanup, and the no-op-update leak invariant (no `mms:Diff` may reference a nonexistent commit). Full suite green (399/399).

## Dependencies

**Stacked on the review-findings branch** (this PR's base): diff creation with user metadata requires the `serializePairs` separator fix from that branch. Retarget to `develop` after it merges.

## Out of scope (needs design)

`/diff/{diffId}/query` remains non-functional: it resolves refs via `mms:commit`, which diffs don't carry, and the intended query semantics (ins/del graph union? named graphs?) are undefined. Left untouched pending a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
