### PR TITLE
fix(squash): make squash usable on real histories

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
@@ -300,6 +300,13 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
                     ?ref mms:commit ?intermediateCommit .
                     filter(?intermediateCommit in ($intermediateFilter))
                     filter(?ref not in (<$srcLockRef>, <$dstLockRef>))
+
+                    # exempt auto-created commit locks (mor-lock:Commit.* with no user etag);
+                    # every commit gets one, and the squash deletes them along with the commits
+                    filter(!(
+                        strstarts(str(?ref), "${prefixes["mor-lock"]}Commit.")
+                        && !exists { ?ref mms:etag ?refUserEtag }
+                    ))
                 }
             }
         """.trimIndent()
@@ -378,11 +385,63 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
         */
         val localConditions = SQUASH_CONDITIONS
 
-        // Build per-node delete patterns for intermediate commits and their data
+        /*
+        collect the auto-created commit locks on the intermediate commits, along with their
+        snapshots and snapshot graphs; the squash owns their cleanup since the commits they
+        reference are being destroyed. user-created refs on intermediates were already rejected
+        by the refCheck above, so these snapshots have no other referents.
+        */
+        var autoLockIris = listOf<String>()
+        var autoSnapshotIris = listOf<String>()
+        var autoSnapshotGraphIris = listOf<String>()
+        if (intermediateCommitIris.isNotEmpty()) {
+            val autoLockQuery = """
+                select ?autoLock ?snapshot ?snapshotGraph where {
+                    graph mor-graph:Metadata {
+                        ?autoLock a mms:Lock ;
+                            mms:commit ?intermediateCommit .
+                        filter(?intermediateCommit in ($intermediateFilter))
+                        filter(strstarts(str(?autoLock), "${prefixes["mor-lock"]}Commit."))
+                        filter not exists { ?autoLock mms:etag ?userEtag }
+
+                        optional {
+                            ?autoLock mms:snapshot ?snapshot .
+                            ?snapshot mms:graph ?snapshotGraph .
+                        }
+                    }
+                }
+            """.trimIndent()
+
+            val autoLockResult = executeSparqlSelectOrAsk(autoLockQuery) {
+                prefixes(prefixes)
+            }
+            val autoLockBindings = parseSparqlResultsJsonSelect(autoLockResult)
+            autoLockIris = autoLockBindings.mapNotNull {
+                it["autoLock"]?.jsonObject?.get("value")?.jsonPrimitive?.content
+            }.distinct()
+            autoSnapshotIris = autoLockBindings.mapNotNull {
+                it["snapshot"]?.jsonObject?.get("value")?.jsonPrimitive?.content
+            }.distinct()
+            autoSnapshotGraphIris = autoLockBindings.mapNotNull {
+                it["snapshotGraph"]?.jsonObject?.get("value")?.jsonPrimitive?.content
+            }.distinct()
+        }
+
+        // Build per-node delete patterns for intermediate commits, their data, and the
+        // auto-created locks/snapshots being garbage-collected
         val intermediateNodePatterns = intermediateCommitIris.mapIndexed { idx, iri ->
             "<$iri> ?ic_p_$idx ?ic_o_$idx ."
         } + intermediateDataIris.mapIndexed { idx, iri ->
             "<$iri> ?id_p_$idx ?id_o_$idx ."
+        } + autoLockIris.mapIndexed { idx, iri ->
+            "<$iri> ?al_p_$idx ?al_o_$idx ."
+        } + autoSnapshotIris.mapIndexed { idx, iri ->
+            "<$iri> ?as_p_$idx ?as_o_$idx ."
+        }
+
+        // registry entries of the snapshot graphs being dropped
+        val registryNodePatterns = autoSnapshotGraphIris.mapIndexed { idx, iri ->
+            "<$iri> ?ag_p_$idx ?ag_o_$idx ."
         }
 
         val intermediateDeletePatterns = intermediateNodePatterns.joinToString("\n                    ")
@@ -391,9 +450,11 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
         // SUM of the nodes' triple counts; joining them in one basic graph pattern would make it
         // the cross-product, which grows exponentially with the number of squashed commits and
         // stalls the quad-store beyond a handful of commits
-        val intermediateWhereUnion = intermediateNodePatterns.joinToString(" union ") {
+        val intermediateWhereUnion = (intermediateNodePatterns.map {
             "{ graph mor-graph:Metadata { $it } }"
-        }
+        } + registryNodePatterns.map {
+            "{ graph m-graph:Graphs { $it } }"
+        }).joinToString(" union ")
 
         // Build delete clauses for old patch data
         val deleteOldDataClauses = mutableListOf(
@@ -421,6 +482,13 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
 
                     // delete old patch/insGraph/delGraph
                     raw(deleteOldDataClauses.joinToString("\n                    "))
+                }
+
+                // delete registry entries of the snapshot graphs being dropped
+                if (registryNodePatterns.isNotEmpty()) {
+                    graph("m-graph:Graphs") {
+                        raw(registryNodePatterns.joinToString("\n                    "))
+                    }
                 }
             }
             insert {
@@ -517,6 +585,8 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
         */
         val graphsToClean = mutableListOf<String>()
         graphsToClean.addAll(intermediateGraphsToClean)
+        // model graphs of the auto-created locks garbage-collected by this squash
+        graphsToClean.addAll(autoSnapshotGraphIris)
         // also drop old ins/del graphs from the newer commit's previous data if they differ from new ones
         if (oldInsGraphIri != null && oldInsGraphIri != diffInsGraphIri) {
             graphsToClean.add(oldInsGraphIri)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
@@ -378,16 +378,22 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
         */
         val localConditions = SQUASH_CONDITIONS
 
-        // Build delete clauses for intermediate commits
-        val intermediateDeletePatterns = if (intermediateCommitIris.isNotEmpty()) {
-            val commitPatterns = intermediateCommitIris.mapIndexed { idx, iri ->
-                "<$iri> ?ic_p_$idx ?ic_o_$idx ."
-            }
-            val dataPatterns = intermediateDataIris.mapIndexed { idx, iri ->
-                "<$iri> ?id_p_$idx ?id_o_$idx ."
-            }
-            (commitPatterns + dataPatterns).joinToString("\n                    ")
-        } else ""
+        // Build per-node delete patterns for intermediate commits and their data
+        val intermediateNodePatterns = intermediateCommitIris.mapIndexed { idx, iri ->
+            "<$iri> ?ic_p_$idx ?ic_o_$idx ."
+        } + intermediateDataIris.mapIndexed { idx, iri ->
+            "<$iri> ?id_p_$idx ?id_o_$idx ."
+        }
+
+        val intermediateDeletePatterns = intermediateNodePatterns.joinToString("\n                    ")
+
+        // each node gets its own union branch in the WHERE clause so the solution space is the
+        // SUM of the nodes' triple counts; joining them in one basic graph pattern would make it
+        // the cross-product, which grows exponentially with the number of squashed commits and
+        // stalls the quad-store beyond a handful of commits
+        val intermediateWhereUnion = intermediateNodePatterns.joinToString(" union ") {
+            "{ graph mor-graph:Metadata { $it } }"
+        }
 
         // Build delete clauses for old patch data
         val deleteOldDataClauses = mutableListOf(
@@ -439,11 +445,9 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
                 // enforce authorization conditions (org/repo existence, UPDATE_COMMIT)
                 raw(*localConditions.requiredPatterns())
 
-                // match intermediate commit triples for deletion
-                if (intermediateDeletePatterns.isNotEmpty()) {
-                    graph("mor-graph:Metadata") {
-                        raw(intermediateDeletePatterns)
-                    }
+                // match intermediate commit triples for deletion (one union branch per node)
+                if (intermediateWhereUnion.isNotEmpty()) {
+                    raw(intermediateWhereUnion)
                 }
 
                 // match old patch data for deletion

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/SquashCommits.kt
@@ -600,14 +600,25 @@ suspend fun LdpDcLayer1Context<LdpPostResponse>.squashCommitsImpl() {
             executeSparqlUpdate(dropStatements)
         }
     } finally {
-        //TODO missing subtxn squash
-        executeSparqlUpdate("""
-            delete where {  
-                graph m-graph:Transactions {
-                    mt: ?p ?o .
+        // delete the base transaction AND the mt:squash subtransaction created by the squash
+        // update; guarded so a failure here cannot mask the original exception or prevent the
+        // diff graph cleanup below
+        try {
+            executeSparqlUpdate("""
+                delete where {
+                    graph m-graph:Transactions {
+                        mt: ?p ?o .
+                    }
+                } ;
+                delete where {
+                    graph m-graph:Transactions {
+                        mt:squash ?sq_p ?sq_o .
+                    }
                 }
-            }
-        """)
+            """)
+        } catch (cleanup: Exception) {
+            log.warn("Failed to delete squash transaction records: ${cleanup.message}")
+        }
         // only clean up temporary diff graphs on failure — on success they are
         // stored as the newer commit's mms:insGraph/mms:delGraph
         if (!squashSucceeded) {

--- a/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
@@ -84,6 +84,17 @@ class SquashCommits : ModelAny() {
                         }
                     }
                 }
+
+                // the squash left no transaction records behind (including mt:squash)
+                withClue("transactions graph should be empty after squash") {
+                    askBackend("""
+                        ASK {
+                            GRAPH <$ROOT_CONTEXT/graphs/Transactions> {
+                                ?txn ?p ?o .
+                            }
+                        }
+                    """.trimIndent()) shouldBe false
+                }
             }
         }
 

--- a/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
@@ -1,6 +1,8 @@
 package org.openmbee.flexo.mms
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.testing.ApplicationTestBuilder
@@ -8,7 +10,83 @@ import org.openmbee.flexo.mms.util.*
 
 
 class SquashCommits : ModelAny() {
+    private fun askBackend(query: String): Boolean {
+        return org.apache.jena.sparql.exec.http.QueryExecutionHTTP.service(backend.getQueryUrl())
+            .query(query).build().use { it.execAsk() }
+    }
+
     init {
+        "squash cleans up auto-created locks on intermediate commits" {
+            testApplication {
+                commitModel(masterBranchPath, insertAliceRex)
+
+                createLock(demoRepoPath, "../branches/master", "lock-older")
+
+                commitModel(masterBranchPath, insertBobFluffy)
+
+                commitModel(masterBranchPath, """
+                    insert data {
+                        <urn:mms:charlie> <urn:mms:name> "Charlie" .
+                    }
+                """.trimIndent())
+
+                createLock(demoRepoPath, "../branches/master", "lock-newer")
+
+                // squash WITHOUT manually deleting the auto-created commit locks
+                httpPost("$demoRepoPath/squash", skipAnon = true) {
+                    setTurtleBody("""
+                        <> mms:srcRef mor-lock:lock-older .
+                        <> mms:dstRef mor-lock:lock-newer .
+                    """.trimIndent())
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.OK
+                }
+
+                val metadataGraph = "${ROOT_CONTEXT}$demoRepoPath/graphs/Metadata"
+
+                // no lock may reference a commit that no longer exists
+                withClue("auto locks of squashed commits should have been deleted") {
+                    askBackend("""
+                        PREFIX mms: <https://mms.openmbee.org/rdf/ontology/>
+                        ASK {
+                            GRAPH <$metadataGraph> {
+                                ?lock a mms:Lock ;
+                                    mms:commit ?commit .
+                                FILTER NOT EXISTS {
+                                    ?commit a mms:Commit .
+                                }
+                            }
+                        }
+                    """.trimIndent()) shouldBe false
+                }
+
+                // no model snapshot may be left without a referencing lock
+                withClue("snapshots of deleted auto locks should have been deleted") {
+                    askBackend("""
+                        PREFIX mms: <https://mms.openmbee.org/rdf/ontology/>
+                        ASK {
+                            GRAPH <$metadataGraph> {
+                                ?snapshot a mms:Model .
+                                FILTER NOT EXISTS {
+                                    ?ref mms:snapshot ?snapshot .
+                                }
+                            }
+                        }
+                    """.trimIndent()) shouldBe false
+                }
+
+                // the model graph is still intact
+                httpGet("$masterBranchPath/graph") {}.apply {
+                    this shouldHaveStatus HttpStatusCode.OK
+                    this.includesTriples {
+                        subject("urn:mms:charlie") {
+                            ignoreAll()
+                        }
+                    }
+                }
+            }
+        }
+
         "happy path: squash 3 commits into 2" {
             testApplication {
                 // commit 1: insert Alice

--- a/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/SquashCommits.kt
@@ -91,6 +91,50 @@ class SquashCommits : ModelAny() {
             }
         }
 
+        "wide squash: squash 8 commits does not stall the store" {
+            testApplication {
+                commitModel(masterBranchPath, insertAliceRex)
+
+                createLock(demoRepoPath, "../branches/master", "lock-older")
+
+                // create 8 intermediate commits
+                for(i in 1..8) {
+                    commitModel(masterBranchPath, """
+                        insert data {
+                            <urn:mms:wide$i> <urn:mms:name> "Wide $i" .
+                        }
+                    """.trimIndent())
+                }
+
+                createLock(demoRepoPath, "../branches/master", "lock-newer")
+
+                // delete auto-created locks on intermediate commits
+                deleteAutoCreatedLocks(backend.getUpdateUrl(), demoRepoPath)
+
+                // squash between the two locks
+                httpPost("$demoRepoPath/squash", skipAnon = true) {
+                    setTurtleBody("""
+                        <> mms:srcRef mor-lock:lock-older .
+                        <> mms:dstRef mor-lock:lock-newer .
+                    """.trimIndent())
+                }.apply {
+                    this shouldHaveStatus HttpStatusCode.OK
+                }
+
+                // the model graph still contains all the data
+                httpGet("$masterBranchPath/graph") {}.apply {
+                    this shouldHaveStatus HttpStatusCode.OK
+                    this.includesTriples {
+                        for(i in 1..8) {
+                            subject("urn:mms:wide$i") {
+                                ignoreAll()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         "non-linear path returns 400" {
             testApplication {
                 // commit on master


### PR DESCRIPTION
## Problem

Squash was unusable on real histories. Every commit's finalization creates an auto lock (`mor-lock:Commit.*`) and the dangling-reference check exempted only the two user-supplied locks, so **any squash spanning real commits was rejected with 400** — the test suite worked around this by hand-deleting the locks from the metadata graph. The consolidated update's WHERE clause also joined one pattern per squashed node into a single BGP, making the solution space the cross-product (~32^k rows for k commits) — squashing more than a handful of commits stalled the store indefinitely. And every squash leaked its `mt:squash` transaction record (the `//TODO` acknowledged it).

## Fix

- **`08db2a4`** — each squashed node is matched in its own UNION branch, so the solution space is the sum of the nodes' triple counts rather than the product.
- **`28225ab`** — auto-created commit locks (Commit. IRI prefix, no user `mms:etag` — the same heuristic as `cleanupPreviousCommitLock`) are exempt from the dangling-reference check, and the squash garbage-collects them: lock/snapshot metadata and `m-graph:Graphs` registry entries are deleted in the same consolidated update, and their model graphs are dropped with the other squash residue. User refs on intermediates are still rejected, so the snapshots have no remaining referents.
- **`8091c63`** — the finally block deletes `mt:squash` as well as `mt:`, and the transaction cleanup can no longer mask the original exception or skip the diff-graph cleanup.

## Tests

`SquashCommits` grows from 5 to 7 tests: an 8-commit wide squash (exercises the union rewrite), and a squash with auto locks present asserting no lock references a deleted commit, no orphan snapshots remain, the model graph is intact, and the transactions graph is empty. Full suite green.

## Dependencies

**Stacked on the review-findings branch** (this PR's base). The dependency is real but infrastructural: that branch's shared-HTTP-client fix is required for the full suite to run at normal speed — without it, leaked per-request clients starve the test JVM and the commit-heavy squash specs run ~15–30x slower (543s vs 19s observed) and hit invocation timeouts. Retarget to `develop` after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
